### PR TITLE
Run checks in Merge Queue, too

### DIFF
--- a/.github/workflows/logstash.yml
+++ b/.github/workflows/logstash.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 jobs:
   build:


### PR DESCRIPTION
I forgot to add the setting we need for our checks to run in the merge queue, too. That means, the queue will wait forever to merge because the checks are never triggered. :-(